### PR TITLE
bug fix: 判断是否有送货地址

### DIFF
--- a/pages/shopping/checkout/checkout.wxml
+++ b/pages/shopping/checkout/checkout.wxml
@@ -13,7 +13,7 @@
                 <image src="/static/images/address_right.png"></image>
             </view>
         </view>
-        <view class="address-item address-empty" bindtap="addAddress" wx:if="{{checkedAddress.id <= 0}}">
+        <view class="address-item address-empty" bindtap="addAddress" wx:if="{{checkedAddress.id == undefined}}">
             <view class="m">
                还没有收货地址，去添加
             </view>


### PR DESCRIPTION
页面判断写错了，因为后端如果查询不到地址，返回的是一个空json对象: {}
因此应该将判断改为checkedAddress.id是否为undefined